### PR TITLE
added multiple attachments support for sending

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -29,7 +29,7 @@ def start():
         4: 'Такого шага не существует.',
         5: 'Такого пользователя не существует.',
         6: 'Существуют только значения "True" и "False" (регистр не важен)',
-        7: 'Вложение не прикрепленно.',
+        7: 'Вложение не прикреплено.',
         8: 'Такого вложения не существует.',
         9: 'Неправильные параметры.'
     }
@@ -116,7 +116,7 @@ def start():
                                 vk=vk,
                                 ID=event.user_id,
                                 message=text_welcome.text,
-                                attachment=text_welcome.attachment
+                                attachment=text_welcome.attachments
                             )
                             texts = json.loads(user.texts)
                             texts.append(text_welcome.text_id)
@@ -200,9 +200,17 @@ def start():
                         elif command == 'update_text':
                             response = commandHandler.update_text(event, args)
 
-                        # update_attachment "{text.title}" "{text.attachment}"
-                        elif command == 'update_attachment':
-                            response = commandHandler.update_attachment(event, args)
+                        # add_attachment "{text.title}" "{text.attachments}"
+                        elif command == 'add_attachments':
+                            response = commandHandler.add_attachments(event, args)
+
+                        # delete_attachments_by_id "{text.title}" "{text.attachments}"
+                        elif command == 'delete_attachments_by_id':
+                            response = commandHandler.delete_attachments_by_id(event, args)
+
+                        # delete_attachments "{text.title}"
+                        elif command == 'delete_attachments':
+                            response = commandHandler.delete_attachments(event, args)
 
                         # update_text_step "{text.title}" "{step.number} | {step.name}"
                         elif command == 'update_text_step':

--- a/app/create_tables.py
+++ b/app/create_tables.py
@@ -52,7 +52,7 @@ class Text(db):
     step = Column(Integer, ForeignKey('step.number', onupdate='cascade', ondelete='cascade'))
     title = Column(String, unique=True)
     text = Column(String)
-    attachment = Column(String, ForeignKey('attachment.name', onupdate='cascade', ondelete='cascade'))
+    attachments = Column(String)
     date = Column(DateTime)
 
 

--- a/app/sending.py
+++ b/app/sending.py
@@ -2,12 +2,14 @@ from vk_api.utils import get_random_id
 from vk_api.keyboard import VkKeyboard
 import vk_api
 import time
+from typing import Optional, Type, List
 
 from config import settings
 from create_tables import get_session, engine, User
 
 
-def message(vk: vk_api.vk_api.VkApiMethod, ID: int, message: str, keyboard=None, attachment=None) -> None:
+def message(vk: Type[vk_api.vk_api.VkApiMethod], ID: Type[int], message: Type[str],
+            keyboard: Optional[vk_api.keyboard.VkKeyboard] = None, attachment: Optional[List[str]] = None) -> None:
     """Функция, отправляющая сообщение пользователю.
 
     :param vk: начатая сессия ВК с авторизацией в сообществе
@@ -23,7 +25,7 @@ def message(vk: vk_api.vk_api.VkApiMethod, ID: int, message: str, keyboard=None,
     :type keyboard: VkKeyboard
 
     :param attachment: необязательное вложение в сообщение
-    :type attachment: str
+    :type attachment: list[str]
 
     :return: ничего не возвращает
     :rtype: None


### PR DESCRIPTION
bot.py:
* fix: fixed attachments field in sending of text_welcome
* feat: added cases for add_attachments, delete_attachments_by_id, delete_attachments functions in command handling

commandHandler.py:
* feat: added standard value ([]) for attachments field in "new_title" function
* fix: fixed value of attachment field for call of send.message in "send_message" function
* feat: added "add_attachments" function for adding multiple number of attachments to text
* feat: added "delete_attachments_by_id" function for deleting given attachments
* feat: added "delete_attachments" function for deleting all attachments of text
* fix: fixed sending message with IDs of attachments in "load" function

sending.py:
* feat: updated argument annotation in "message" function

create_tables.py:
* fix: deleted ForeignKey constraint of Text.attachments field